### PR TITLE
auto export symbols for msvc builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.18)
-project(VegaFEM CXX)
+project(VegaFEM CXX C)
 set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 
 # configuration options
@@ -9,6 +11,7 @@ option(VEGA_USE_GLEW "Build OpenGL shaders using GLEW" OFF)
 option(VEGA_USE_GLUT "Build components that depend on GLUT" OFF)
 option(VEGA_USE_CG_TOOLKIT "Build GPU components using Cg Toolkit" OFF)
 option(VEGA_USE_CGAL "Build meshing components using CGAL" OFF)
+option(VEGA_USE_EXPOKIT "Build matrix exponentials using Expokit" OFF)
 option(VEGA_BUILD_UTILITIES "Build utilities" OFF)
 
 
@@ -34,10 +37,6 @@ if(VEGA_USE_GLEW)
 	list(APPEND VEGA_DEPENDENCIES GLEW::GLEW) # glew_s for static
 endif()
 
-if(VEGA_USE_CG_TOOLKIT)
-	find_package(Cg QUIET) # todo: this does not work yet
-endif()
-
 if(VEGA_USE_CGAL)
 	find_package(CGAL REQUIRED)
 	find_path(IGL_INCLUDE_DIRS igl/harmonic.h PATHS $ENV{IGL_ROOT}/include REQUIRED)
@@ -55,6 +54,14 @@ else()
 	find_package(BLAS REQUIRED)
 	find_package(LAPACK REQUIRED)
 	list(APPEND VEGA_DEPENDENCIES BLAS::BLAS LAPACK::LAPACK)
+endif()
+
+if(VEGA_USE_CG_TOOLKIT)
+	message(FATAL_ERROR "Cg toolkit not supported")
+endif()
+
+if (VEGA_USE_EXPOKIT)
+	message(FATAL_ERROR "Expkit not supported")
 endif()
 
 
@@ -162,6 +169,10 @@ foreach(lib ${VEGA_LIBRARIES})
 endforeach()
 
 add_library(vega ${OBJECT_FILES})
+if(BUILD_SHARED_LIBS)
+	set_target_properties(vega PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+	target_link_libraries(vega ${VEGA_DEPENDENCIES})
+endif()
 
 
 # build utilities

--- a/libraries/include/vega-config.h.in
+++ b/libraries/include/vega-config.h.in
@@ -3,6 +3,7 @@
 #cmakedefine VEGA_USE_INTEL_MKL
 #cmakedefine VEGA_USE_PARDISO
 #cmakedefine VEGA_USE_SPOOLES
+#cmakedefine VEGA_USE_EXPOKIT
 #cmakedefine VEGA_USE_GLUT
 
 #if defined(__APPLE__) && !defined(VEGA_USE_INTEL_MKL)

--- a/libraries/matrix/CMakeLists.txt
+++ b/libraries/matrix/CMakeLists.txt
@@ -1,10 +1,13 @@
 set(SRCS
     matrix.cpp
     matrixBLAS.cpp
-    matrixExp.cpp
     matrixLAPACK.cpp
     matrixPCA.cpp
     matrixProjection.cpp
 )
+if (VEGA_USE_EXPOKIT)
+    list(APPEND SRCS matrixExp.cpp)
+endif()
+
 add_library(matrix OBJECT ${SRCS})
 target_link_libraries(matrix PRIVATE matrixIO ${VEGA_DEPENDENCIES})

--- a/libraries/matrix/matrix.cpp
+++ b/libraries/matrix/matrix.cpp
@@ -390,7 +390,7 @@ int Matrix<real>::LUSolve(Matrix<real> & x, const Matrix<real> & rhs)
   return exitCode;
 }
 
-#ifdef USE_EXPOKIT
+#ifdef VEGA_USE_EXPOKIT
 
 template<class real>
 void Matrix<real>::MExpv(real t, const Matrix<real> & v, Matrix<real> & w)

--- a/libraries/matrix/matrix.h
+++ b/libraries/matrix/matrix.h
@@ -61,11 +61,10 @@
 #include "matrixMacros.h"
 #include "matrixBLAS.h"
 #include "matrixLAPACK.h"
+#include "vega-config.h"
 
-// uncomment the following to use the MExpv and MExp routines:
-//#define USE_EXPOKIT
 
-#ifdef USE_EXPOKIT
+#ifdef VEGA_USE_EXPOKIT
   #include "matrixExp.h"
 #endif
 
@@ -183,7 +182,7 @@ public:
 
   // === matrix exponential routines ===
 
-  // In order to use these routines, you must enable the USE_EXPOKIT definition in the header of matrix.h (disabled by default to avoid linker problems when expokit is not used), and link your code against the expokit library:
+  // In order to use these routines, you must enable the VEGA_USE_EXPOKIT definition in the header of matrix.h (disabled by default to avoid linker problems when expokit is not used), and link your code against the expokit library:
   // http://www.maths.uq.edu.au/expokit/
   // The expokit routines compute the matrix exponential of a general matrix in
   // full, using the irreducible rational Pade approximation to the 
@@ -300,7 +299,7 @@ inline const Matrix<real> LeastSquareSolve(const Matrix<real> & mtx, const Matri
 template<class real>
 inline const Matrix<real> MExp(real t, const Matrix<real> & mtx, int * code)
 {
-  #ifdef USE_EXPOKIT
+  #ifdef VEGA_USE_EXPOKIT
     if (mtx.Getm() != mtx.Getn())
     {    
       printf("Matrix size mismatch in Matrix::MExp . mtx.m = %d, mtx.n = %d\n", mtx.Getm(), mtx.Getn());

--- a/libraries/matrix/matrixExp.cpp
+++ b/libraries/matrix/matrixExp.cpp
@@ -41,13 +41,11 @@
 #include "matrixExp.h"
 
 #ifdef __APPLE__
-  #define DGPADM dgpadm_
-  #define SGPADM sgpadm_
-  #define INTEGER long int
+#define DGPADM dgpadm_
+#define SGPADM sgpadm_
 #else
-  #define DGPADM dgpadm_
-  #define SGPADM sgpadm_
-  #define INTEGER int
+#define DGPADM dgpadm_
+#define SGPADM sgpadm_
 #endif
 
 template<bool C>

--- a/libraries/mesh/CMakeLists.txt
+++ b/libraries/mesh/CMakeLists.txt
@@ -3,10 +3,12 @@ set(SRCS
     createTriMesh.cpp
     exactOctree.cpp
     geometryQuery.cpp
+    initPredicates.cpp
     intersection_tunicate.cpp
     labelOuterTets.cpp
     meshIntersection.cpp
     predicates.cpp
+    predicates_Shewchuk.c
     rectKey.cpp
     simpleSphere.cpp
     tetKey.cpp

--- a/libraries/mesh/initPredicates.cpp
+++ b/libraries/mesh/initPredicates.cpp
@@ -1,0 +1,8 @@
+#include "initPredicates.h"
+
+extern "C" void exactinit();
+
+void initPredicates()
+{
+	exactinit();
+}

--- a/libraries/mesh/predicates.cpp
+++ b/libraries/mesh/predicates.cpp
@@ -72,11 +72,6 @@ int simplex_intersection3d(int k, const double* x0, const double* x1, const doub
 
 // -------------------------------------------------------------
 
-void initPredicates()
-{
-  exactinit();
-}
-
 double orient2d(const double pa[2], const double pb[2], const double pc[2])
 {
   return orient2d((double*)pa, (double*)pb, (double*)pc);

--- a/libraries/sparseSolver/CMakeLists.txt
+++ b/libraries/sparseSolver/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(SRCS
-    ARPACKSolver.cpp
+    #ARPACKSolver.cpp
     CGSolver.cpp
     invMKSolver.cpp
     invZTAZMSolver.cpp


### PR DESCRIPTION
- use `WINDOWS_EXPORT_ALL_SYMBOLS=ON` flag to automatically export symbols for Windows DLLs
- fix a few places where this breaks (e.g. initPredicates.h, where definition was in `predicates.cpp`)
- building a DLL identified several other issues, e.g. `predicates_Shewchuk.c` was not built