### PR TITLE
various fixes for tbb & mkl use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,7 @@ list(APPEND VEGA_DEPENDENCIES OpenGL::GL)
 
 if(VEGA_USE_TBB)
   find_package(TBB REQUIRED)
-  get_target_property(TBB_INCLUDE_DIRS TBB::tbb INTERFACE_INCLUDE_DIRECTORIES)
-  list(APPEND VEGA_DEPENDENCIES ${TBB_IMPORTED_TARGETS})
-  include_directories(${TBB_INCLUDE_DIRS})
+  list(APPEND VEGA_DEPENDENCIES TBB::tbb)
 endif()
 
 if(VEGA_USE_GLUT)
@@ -66,14 +64,6 @@ else()
       set(VEGA_USE_INTEL_MKL ON)
     endif()
   endforeach()
-  if(VEGA_USE_INTEL_MKL)
-    get_target_property(TARGET_BLAS_INCLUDE_DIRS BLAS::BLAS
-                        INTERFACE_INCLUDE_DIRECTORIES)
-    message(STATUS "TARGET_BLAS_INCLUDE_DIRS: ${TARGET_BLAS_INCLUDE_DIRS}")
-    find_path(BLAS_INCLUDE_DIRS mkl_cblas.h
-              PATHS /usr/include /usr/local/include /usr/include/mkl REQUIRED)
-    include_directories(${BLAS_INCLUDE_DIRS})
-  endif()
   message(STATUS "Using Intel MKL: ${VEGA_USE_INTEL_MKL}")
 endif()
 
@@ -188,6 +178,9 @@ target_link_libraries(vega ${VEGA_DEPENDENCIES})
 if(BUILD_SHARED_LIBS)
   set_target_properties(vega PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
+
+# make sure config is visible
+target_precompile_headers(vega PRIVATE "${CMAKE_BINARY_DIR}/vega-config.h")
 
 # build utilities
 if(VEGA_BUILD_UTILITIES)

--- a/libraries/include/vega-config.h.in
+++ b/libraries/include/vega-config.h.in
@@ -10,3 +10,11 @@
 #if defined(__APPLE__) && !defined(VEGA_USE_INTEL_MKL)
     #define VEGA_USE_ACCELERATE
 #endif
+
+#ifdef VEGA_USE_TBB
+    #define USE_TBB
+#endif
+
+#ifdef VEGA_USE_INTEL_MKL
+    #define USE_INTEL_MKL
+#endif

--- a/libraries/integratorSparse/centralDifferencesSparse.h
+++ b/libraries/integratorSparse/centralDifferencesSparse.h
@@ -32,33 +32,35 @@
 
 /*
 
-A class to timestep dynamics (e.g. nonlinear deformable FEM) 
-using the EXPLICIT central differences integrator. Normally, the implicit newmark and
-implicit backward Euler classes are recommended for nonlinear deformable FEM
-due to stability under large deformations.  See also integratorBase.h.
+A class to timestep dynamics (e.g. nonlinear deformable FEM)
+using the EXPLICIT central differences integrator. Normally, the implicit
+newmark and implicit backward Euler classes are recommended for nonlinear
+deformable FEM due to stability under large deformations.  See also
+integratorBase.h.
 
 This implementation follows
 WRIGGERS P.: Computational Contact Mechanics. John
 Wiley & Sons, Ltd., 2002., page 275
 
-This class supports two damping modes: 
+This class supports two damping modes:
 1. Standard Rayleigh model
   D = dampingMassCoef * M + dampingStiffnessCoef * K
      where K is the stiffness matrix AT THE ORIGIN
 2. Tangential Rayleigh model (default)
   D = dampingMassCoef * M + dampingStiffnessCoef * K(q)
-     where K is the tangential stiffness matrix in the CURRENT deformed configuration q
+     where K is the tangential stiffness matrix in the CURRENT deformed
+configuration q
 
-Mode 1. is computationally faster as it does not require system updates (i.e., 
-matrix inversion). Mode 1. is useful, for example, if you want to timestep 
+Mode 1. is computationally faster as it does not require system updates (i.e.,
+matrix inversion). Mode 1. is useful, for example, if you want to timestep
 linear modal analysis simulations (stiffness matrix is constant in that case).
 
 Mode 2. gives a better damping model for large deformations, but because the
 system matrix changes, requires factoring a linear system anew at each timestep.
 
-In order to use this class, you need to set the timestep very small, or 
-else the explicit integrator will go unstable. Roughly speaking, the timestep 
-must resolve the highest frequency present in your simulation. 
+In order to use this class, you need to set the timestep very small, or
+else the explicit integrator will go unstable. Roughly speaking, the timestep
+must resolve the highest frequency present in your simulation.
 
 See also integratorBase.h .
 
@@ -68,68 +70,63 @@ See also integratorBase.h .
 #define _CENTRALDIFFERENCESSPARSE_H_
 
 #include "integratorBaseSparse.h"
-#include "integratorSolverSelection.h"
 
-#ifdef PARDISO
-  #include "sparseSolvers.h"
-#endif
-#ifdef SPOOLES
-  #include "sparseSolvers.h"
-#endif
-#ifdef PCG
-  #include "CGSolver.h"
-#endif
+class PardisoSolver;
+class LinearSolver;
+class CGSolver;
 
-class CentralDifferencesSparse : public IntegratorBaseSparse
-{
+class CentralDifferencesSparse : public IntegratorBaseSparse {
 public:
-  CentralDifferencesSparse(int numDOFs, double timestep, SparseMatrix * massMatrix, ForceModel * forceModel, int numConstrainedDOFs=0, int * constrainedDOFs=NULL, double dampingMassCoef=0.0, double dampingStiffnessCoef=0.0, int tangentialDampingMode=1, int numSolverThreads=0);
+  CentralDifferencesSparse(int numDOFs, double timestep,
+                           SparseMatrix *massMatrix, ForceModel *forceModel,
+                           int numConstrainedDOFs = 0,
+                           int *constrainedDOFs = NULL,
+                           double dampingMassCoef = 0.0,
+                           double dampingStiffnessCoef = 0.0,
+                           int tangentialDampingMode = 1,
+                           int numSolverThreads = 0);
 
   virtual ~CentralDifferencesSparse();
 
-  inline virtual void SetTimestep(double timestep) { this->timestep = timestep; DecomposeSystemMatrix(); }
+  inline virtual void SetTimestep(double timestep) {
+    this->timestep = timestep;
+    DecomposeSystemMatrix();
+  }
 
   // performs one timestep of simulation
-  virtual int DoTimestep(); 
+  virtual int DoTimestep();
 
-  // sets q, and (optionally) qvel 
-  // returns 0 
-  virtual int SetState(double * q, double * qvel=NULL);
+  // sets q, and (optionally) qvel
+  // returns 0
+  virtual int SetState(double *q, double *qvel = NULL);
 
-  // tangentialDampingMode: 
-  // 0 = no updates of the damping matrix under deformations (not recommended for large deformations)
-  // 1 = update at every timestep (default)
-  // k>1 = update every kth timestep
-  inline void SetTangentialDampingMode(int tangentialDampingMode) { this->tangentialDampingMode = tangentialDampingMode; }
+  // tangentialDampingMode:
+  // 0 = no updates of the damping matrix under deformations (not recommended
+  // for large deformations) 1 = update at every timestep (default) k>1 = update
+  // every kth timestep
+  inline void SetTangentialDampingMode(int tangentialDampingMode) {
+    this->tangentialDampingMode = tangentialDampingMode;
+  }
 
   virtual void SetInternalForceScalingFactor(double internalForceScalingFactor);
 
   virtual void ResetToRest();
 
 protected:
-  double * rhs;
-  double * rhsConstrained;
-  SparseMatrix * rayleighDampingMatrix;
-  SparseMatrix * tangentStiffnessMatrix;
-  SparseMatrix * systemMatrix;
+  double *rhs;
+  double *rhsConstrained;
+  SparseMatrix *rayleighDampingMatrix;
+  SparseMatrix *tangentStiffnessMatrix;
+  SparseMatrix *systemMatrix;
   int tangentialDampingMode;
   int numSolverThreads;
   int timestepIndex;
 
   void DecomposeSystemMatrix();
 
-  #ifdef PARDISO
-    PardisoSolver * pardisoSolver;
-  #endif
-
-  #ifdef SPOOLES
-    LinearSolver * spoolesSolver;
-  #endif
-
-  #ifdef PCG
-    CGSolver * jacobiPreconditionedCGSolver;
-  #endif
+  PardisoSolver *pardisoSolver = nullptr;
+  LinearSolver *spoolesSolver = nullptr;
+  CGSolver *jacobiPreconditionedCGSolver = nullptr;
 };
 
 #endif
-

--- a/libraries/integratorSparse/eulerSparse.cpp
+++ b/libraries/integratorSparse/eulerSparse.cpp
@@ -37,6 +37,17 @@
 #include "performanceCounter.h"
 #include "constrainedDOFs.h"
 #include "eulerSparse.h"
+#include "integratorSolverSelection.h"
+
+#ifdef PARDISO
+  #include "sparseSolvers.h"
+#endif
+#ifdef SPOOLES
+  #include "sparseSolvers.h"
+#endif
+#ifdef PCG
+  #include "CGSolver.h"
+#endif
 
 EulerSparse::EulerSparse(int r, double timestep, SparseMatrix * massMatrix_, ForceModel * forceModel_, int symplectic_, int numConstrainedDOFs_, int * constrainedDOFs_, double dampingMassCoef, int numSolverThreads): IntegratorBaseSparse(r, timestep, massMatrix_, forceModel_, numConstrainedDOFs_, constrainedDOFs_, dampingMassCoef, 0.0), symplectic(symplectic_)
 {
@@ -107,7 +118,7 @@ int EulerSparse::DoTimestep()
   // store current state
   for(int i=0; i<r; i++)
   {
-    q_1[i] = q[i]; 
+    q_1[i] = q[i];
     qvel_1[i] = qvel[i];
     qaccel_1[i] = qaccel[i];
   }
@@ -180,7 +191,7 @@ int EulerSparse::DoTimestep()
     {
       qvel[i] += timestep * qdelta[i];
       q[i] += timestep * qvel[i];
-    }	
+    }
   }
   else
   {
@@ -200,4 +211,3 @@ int EulerSparse::DoTimestep()
 
   return 0;
 }
-

--- a/libraries/integratorSparse/eulerSparse.h
+++ b/libraries/integratorSparse/eulerSparse.h
@@ -31,7 +31,8 @@
  *************************************************************************/
 
 /*
-  A class to timestep large sparse dynamics using standard Euler, or symplectic Euler.
+  A class to timestep large sparse dynamics using standard Euler, or symplectic
+  Euler.
 
   standard Euler:
   x_{n+1} = x_n + h * v_n
@@ -45,54 +46,40 @@
 #ifndef _EULERSPARSE_H_
 #define _EULERSPARSE_H_
 
-#include "integratorSolverSelection.h"
 #include "integratorBaseSparse.h"
 
-#ifdef PARDISO
-  #include "sparseSolvers.h"
-#endif
-#ifdef SPOOLES
-  #include "sparseSolvers.h"
-#endif
-#ifdef PCG
-  #include "CGSolver.h"
-#endif
+class PardisoSolver;
+class SPOOLESSolver;
+class CGSolver;
 
-
-class EulerSparse : public IntegratorBaseSparse
-{
+class EulerSparse : public IntegratorBaseSparse {
 public:
-
-  // constrainedDOFs is an integer array of degrees of freedom that are to be fixed to zero (e.g., to permanently fix a vertex in a deformable simulation)
-  // constrainedDOFs are 0-indexed (separate DOFs for x,y,z), and must be pre-sorted (ascending)
-  // dampingMatrix is optional and provides damping (in addition to mass damping)
-  EulerSparse(int r, double timestep, SparseMatrix * massMatrix, ForceModel * forceModel, int symplectic=0, int numConstrainedDOFs=0, int * constrainedDOFs=NULL, double dampingMassCoef=0.0, int numSolverThreads=1);
+  // constrainedDOFs is an integer array of degrees of freedom that are to be
+  // fixed to zero (e.g., to permanently fix a vertex in a deformable
+  // simulation) constrainedDOFs are 0-indexed (separate DOFs for x,y,z), and
+  // must be pre-sorted (ascending) dampingMatrix is optional and provides
+  // damping (in addition to mass damping)
+  EulerSparse(int r, double timestep, SparseMatrix *massMatrix,
+              ForceModel *forceModel, int symplectic = 0,
+              int numConstrainedDOFs = 0, int *constrainedDOFs = NULL,
+              double dampingMassCoef = 0.0, int numSolverThreads = 1);
 
   virtual ~EulerSparse();
 
-  // sets q, and (optionally) qvel 
-  // returns 0 
-  virtual int SetState(double * q, double * qvel=NULL);
+  // sets q, and (optionally) qvel
+  // returns 0
+  virtual int SetState(double *q, double *qvel = NULL);
 
-  virtual int DoTimestep(); 
+  virtual int DoTimestep();
 
 protected:
   int symplectic;
-  SparseMatrix * systemMatrix;
-  double * bufferConstrained;
-  
-  #ifdef PARDISO
-    PardisoSolver * pardisoSolver;
-  #endif
+  SparseMatrix *systemMatrix;
+  double *bufferConstrained;
 
-  #ifdef SPOOLES
-    SPOOLESSolver * spoolesSolver;
-  #endif
-
-  #ifdef PCG
-    CGSolver * jacobiPreconditionedCGSolver;
-  #endif
+  PardisoSolver *pardisoSolver = nullptr;
+  SPOOLESSolver *spoolesSolver = nullptr;
+  CGSolver *jacobiPreconditionedCGSolver = nullptr;
 };
 
 #endif
-

--- a/libraries/integratorSparse/implicitBackwardEulerSparse.cpp
+++ b/libraries/integratorSparse/implicitBackwardEulerSparse.cpp
@@ -37,6 +37,14 @@
 #include "performanceCounter.h"
 #include "constrainedDOFs.h"
 #include "implicitBackwardEulerSparse.h"
+#include "integratorSolverSelection.h"
+
+#ifdef PARDISO
+  #include "sparseSolvers.h"
+#endif
+#ifdef PCG
+  #include "CGSolver.h"
+#endif
 
 ImplicitBackwardEulerSparse::ImplicitBackwardEulerSparse(int r, double timestep, SparseMatrix * massMatrix_, ForceModel * forceModel_, int numConstrainedDOFs_, int * constrainedDOFs_, double dampingMassCoef, double dampingStiffnessCoef, int maxIterations, double epsilon, int numSolverThreads_): ImplicitNewmarkSparse(r, timestep, massMatrix_, forceModel_, numConstrainedDOFs_, constrainedDOFs_, dampingMassCoef, dampingStiffnessCoef, maxIterations, epsilon, 0.25, 0.5, numSolverThreads_)
 {
@@ -69,7 +77,7 @@ int ImplicitBackwardEulerSparse::DoTimestep()
   for(int i=0; i<r; i++)
   {
     qaccel_1[i] = qaccel[i] = 0; // acceleration is actually not used in this integrator
-    q_1[i] = q[i]; 
+    q_1[i] = q[i];
     qvel_1[i] = qvel[i];
   }
 
@@ -124,7 +132,7 @@ int ImplicitBackwardEulerSparse::DoTimestep()
       if (tangentStiffnessMatrixOffset != NULL)
         tangentStiffnessMatrix->AddSubMatrix(1.0, *tangentStiffnessMatrixOffset, 2);
 
-      // build effective stiffness: 
+      // build effective stiffness:
       // Keff = M + h D + h^2 * K
       // compute force residual, store it into aux variable qresidual
       // qresidual = h * (-D qdot - fint + fext - h * K * qdot)) // this is semi-implicit Euler
@@ -194,7 +202,7 @@ int ImplicitBackwardEulerSparse::DoTimestep()
     //printf("numIter: %d error2: %G\n", numIter, error);
 
     // on the first iteration, compute initial error
-    if (numIter == 0) 
+    if (numIter == 0)
     {
       error0 = error;
       errorQuotient = 1.0;
@@ -202,7 +210,7 @@ int ImplicitBackwardEulerSparse::DoTimestep()
     else
     {
       // error divided by the initial error, before performing this iteration
-      errorQuotient = error / error0; 
+      errorQuotient = error / error0;
     }
 
     if (errorQuotient < epsilon * epsilon)
@@ -309,4 +317,3 @@ int ImplicitBackwardEulerSparse::DoTimestep()
 
   return 0;
 }
-

--- a/libraries/integratorSparse/implicitNewmarkSparse.h
+++ b/libraries/integratorSparse/implicitNewmarkSparse.h
@@ -36,7 +36,7 @@
 
   See also integratorBase.h .
 
-  This class either uses SPOOLES, PARDISO, or our own Jacobi-preconitioned 
+  This class either uses SPOOLES, PARDISO, or our own Jacobi-preconitioned
   CG to solve the large sparse linear systems.
 
   You can switch between these solvers at compile time,
@@ -48,89 +48,96 @@
 #define _IMPLICITNEWMARKSPARSE_H_
 
 #ifdef __APPLE__
-  #include "TargetConditionals.h"
+#include "TargetConditionals.h"
 #endif
 
-// This code supports three different solvers for sparse linear systems of equations:
-// SPOOLES, PARDISO, Jacobi-preconditioned Conjugate Gradients
-// You must define exactly one of the macros SPOOLES, PARDISO, PCG,
-// by changing the file integratorSolverSelection.h .
-// PCG is available with our code; look for it in the "sparseMatrix" library (CGSolver.h)
-// SPOOLES is available at: http://www.netlib.org/linalg/spooles/spooles.2.2.html
-// For PARDISO, the class was tested with the PARDISO implementation from the Intel Math Kernel Library
+// This code supports three different solvers for sparse linear systems of
+// equations: SPOOLES, PARDISO, Jacobi-preconditioned Conjugate Gradients You
+// must define exactly one of the macros SPOOLES, PARDISO, PCG, by changing the
+// file integratorSolverSelection.h . PCG is available with our code; look for
+// it in the "sparseMatrix" library (CGSolver.h) SPOOLES is available at:
+// http://www.netlib.org/linalg/spooles/spooles.2.2.html For PARDISO, the class
+// was tested with the PARDISO implementation from the Intel Math Kernel Library
 
-#include "integratorSolverSelection.h"
-#include "sparseMatrix.h"
 #include "integratorBaseSparse.h"
+#include "sparseMatrix.h"
 
-#ifdef PARDISO
-  #include "sparseSolvers.h"
-#endif
-#ifdef SPOOLES
-  #include "sparseSolvers.h"
-#endif
-#ifdef PCG
-  #include "CGSolver.h"
-#endif
+class PardisoSolver;
+class CGSolver;
 
-class ImplicitNewmarkSparse : public IntegratorBaseSparse
-{
+class ImplicitNewmarkSparse : public IntegratorBaseSparse {
 public:
-
-  // constrainedDOFs is an integer array of degrees of freedom that are to be fixed to zero (e.g., to permanently fix a vertex in a deformable simulation)
-  // constrainedDOFs are 0-indexed (separate DOFs for x,y,z), and must be pre-sorted (ascending)
-  // numThreads applies only to the PARDISO solver; if numThreads > 0, the sparse linear solves are multi-threaded; default: 0 (use single-threading)
-  ImplicitNewmarkSparse(int r, double timestep, SparseMatrix * massMatrix, ForceModel * forceModel, int numConstrainedDOFs=0, int * constrainedDOFs=NULL, double dampingMassCoef=0.0, double dampingStiffnessCoef=0.0, int maxIterations = 1, double epsilon = 1E-6, double NewmarkBeta=0.25, double NewmarkGamma=0.5, int numSolverThreads=0); 
+  // constrainedDOFs is an integer array of degrees of freedom that are to be
+  // fixed to zero (e.g., to permanently fix a vertex in a deformable
+  // simulation) constrainedDOFs are 0-indexed (separate DOFs for x,y,z), and
+  // must be pre-sorted (ascending) numThreads applies only to the PARDISO
+  // solver; if numThreads > 0, the sparse linear solves are multi-threaded;
+  // default: 0 (use single-threading)
+  ImplicitNewmarkSparse(int r, double timestep, SparseMatrix *massMatrix,
+                        ForceModel *forceModel, int numConstrainedDOFs = 0,
+                        int *constrainedDOFs = NULL,
+                        double dampingMassCoef = 0.0,
+                        double dampingStiffnessCoef = 0.0,
+                        int maxIterations = 1, double epsilon = 1E-6,
+                        double NewmarkBeta = 0.25, double NewmarkGamma = 0.5,
+                        int numSolverThreads = 0);
 
   virtual ~ImplicitNewmarkSparse();
 
-  // damping matrix provides damping in addition to mass and stiffness damping (it does not replace it)
-  virtual void SetDampingMatrix(SparseMatrix * dampingMatrix);
-  inline virtual void SetTimestep(double timestep) { this->timestep = timestep; UpdateAlphas(); }
+  // damping matrix provides damping in addition to mass and stiffness damping
+  // (it does not replace it)
+  virtual void SetDampingMatrix(SparseMatrix *dampingMatrix);
+  inline virtual void SetTimestep(double timestep) {
+    this->timestep = timestep;
+    UpdateAlphas();
+  }
 
-  // sets q, qvel 
+  // sets q, qvel
   // automatically computes acceleration assuming zero external force
   // returns 0 on succes, 1 if solver fails to converge
   // note: there are also other state setting routines in the base class
-  virtual int SetState(double * q, double * qvel=NULL);
+  virtual int SetState(double *q, double *qvel = NULL);
 
   // see parent class for usage
-  virtual void SetTangentStiffnessMatrixOffset(SparseMatrix * tangentStiffnessMatrixOffset, int reuseTopology=1);
+  virtual void
+  SetTangentStiffnessMatrixOffset(SparseMatrix *tangentStiffnessMatrixOffset,
+                                  int reuseTopology = 1);
 
   // performs one step of simulation (returns 0 on sucess, and 1 on failure)
-  virtual int DoTimestep(); 
+  virtual int DoTimestep();
 
-  inline void SetNewmarkBeta(double NewmarkBeta) { this->NewmarkBeta = NewmarkBeta; UpdateAlphas(); }
-  inline void SetNewmarkGamma(double NewmarkGamma) { this->NewmarkGamma = NewmarkGamma; UpdateAlphas(); }
+  inline void SetNewmarkBeta(double NewmarkBeta) {
+    this->NewmarkBeta = NewmarkBeta;
+    UpdateAlphas();
+  }
+  inline void SetNewmarkGamma(double NewmarkGamma) {
+    this->NewmarkGamma = NewmarkGamma;
+    UpdateAlphas();
+  }
 
   // dynamic solver is default (i.e. useStaticSolver=false)
   virtual void UseStaticSolver(bool useStaticSolver);
 
 protected:
-  SparseMatrix * rayleighDampingMatrix;
-  SparseMatrix * tangentStiffnessMatrix;
-  SparseMatrix * systemMatrix;
+  SparseMatrix *rayleighDampingMatrix;
+  SparseMatrix *tangentStiffnessMatrix;
+  SparseMatrix *systemMatrix;
 
-  double * bufferConstrained;
+  double *bufferConstrained;
 
   // parameters for implicit Newmark
-  double NewmarkBeta,NewmarkGamma;
+  double NewmarkBeta, NewmarkGamma;
   double alpha1, alpha2, alpha3, alpha4, alpha5, alpha6;
-  double epsilon; 
+  double epsilon;
   int maxIterations;
 
   void UpdateAlphas();
   bool useStaticSolver;
 
   int numSolverThreads;
-  #ifdef PARDISO
-    PardisoSolver * pardisoSolver;
-  #endif
 
-  #ifdef PCG
-    CGSolver * jacobiPreconditionedCGSolver;
-  #endif
+  PardisoSolver *pardisoSolver = nullptr;
+  CGSolver *jacobiPreconditionedCGSolver = nullptr;
 };
 
 #endif
-

--- a/libraries/sparseSolver/PardisoSolver.h
+++ b/libraries/sparseSolver/PardisoSolver.h
@@ -40,14 +40,14 @@
     symmetric indefinite matrix
     unsymmetric matrix
   The solution is obtained using the Pardiso library from Intel MKL, using multi-threading.
-  Three steps are performed: 
+  Three steps are performed:
     1. matrix re-ordering and symbolic factorization (in the constructor)
     2. numerical matrix factorization (FactorMatrix)
     3. the actual linear system solve (SolveLinearSystem)
-  The solution method is direct (not iterative), unless one uses the direct-iterative mode. 
+  The solution method is direct (not iterative), unless one uses the direct-iterative mode.
   As such, convergence is robust, and there is no need to tune convergence parameters, unlike, say, in the conjugate gradient method.
   Memory requirements are minimized by re-ordering the matrix before applying the matrix decomposition.
-  However, for very large systems (e.g. matrices of size 200,000 x 200,000, on a machine with 2 GB RAM), 
+  However, for very large systems (e.g. matrices of size 200,000 x 200,000, on a machine with 2 GB RAM),
   the matrix decomposition might run out of memory.
 */
 
@@ -88,7 +88,7 @@ public:
   // You must factor the matrix at least once; and every time the entries of the matrix A change.
   // If the topology of A changes, you must call the constructor again.
   // A is not modified.
-  MKL_INT FactorMatrix(const SparseMatrix * A); 
+  MKL_INT FactorMatrix(const SparseMatrix * A);
 
   // solve: A * x = rhs, using the previously computed matrix factorization
   // rhs is not modified
@@ -117,15 +117,14 @@ protected:
   MKL_INT iparm[64];
 
   int numThreads;
-  matrixType mtype;
-  reorderingType rtype;
+  MKL_INT mtype;
+  MKL_INT rtype;
   int directIterative;
   int verbose;
-  MKL_INT nrhs; 
+  MKL_INT nrhs;
   MKL_INT maxfct, mnum, phase, error, msglvl;
 
   static void DisabledSolverError();
 };
 
 #endif
-


### PR DESCRIPTION
Fixes following issues
- PardisoSolver an enum pointer was casted / passed to mkl functions as `int*`
- `USE_TBB` and `USE_INTEL_MKL` was not defined in compilation units
- #13 (moved header inclusion to .cpp, forward declare solver classes)